### PR TITLE
SonarQube is now only triggered when the build is on the dev branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,9 @@ pipeline {
             }
         }
         stage('quality analysis'){
+            when {
+                branch 'dev'
+            }
             environment {
                 scannerHome = tool 'SonarQubeScanner'
             }


### PR DESCRIPTION
We decided that sonarqube should only be triggered when the build is started from the dev branch.